### PR TITLE
Update README.md - Added PowerShell note to Unblock nodist.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `v` in front of a version number is optional.
 
 All commands implicitly install the specified version before using it, if it isn't already installed.
 
-Btw, nodist also works in your PowerShell.
+Btw, nodist also works in your PowerShell, but you might first need to 'Unblock' the file `\bin\nodist.ps1`.
 
 ### Install a version
 Checks, if the version is installed and downloads it if not.


### PR DESCRIPTION
I get this error, and I imagine everyone running PowerShell inside a Windows Domain, will see the same:

```
PS C:\Users\bvandermeer\Source> nodist
nodist : File C:\Users\bvandermeer\.nodist\bin\nodist.ps1 cannot be loaded. The file C:\Users\bvandermeer\.nodist\bin\nodist.ps1 is not digitally signed. The script
will not execute on the system. For more information, see about_Execution_Policies at http://go.microsoft.com/fwlink/?LinkID=135170.
At line:1 char:1
+ nodist
+ ~~~~~~
    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess
```

The Fix is easy, just 'Unblock' te file.
