### PR TITLE
chocolatey batch redirect fix

### DIFF
--- a/lib/nodist.js
+++ b/lib/nodist.js
@@ -274,6 +274,7 @@ nodist.prototype.fetch = function fetch(version, callback) {
   writer.on('error', function(err) {
     cb(new Error('Couldn\'t write fetched version '+version+': '+err.message));
   });
+  fs.writeFile(fetch_target + '.ignore', '');
 };
 
 /**


### PR DESCRIPTION
The current chocolatey installed nodist will result in redirecting node to the wrong version.
In my case, it redirects to the internal node.exe used by nodist. 
The fix is simple add a node.exe.ignore next to the node.exe used internally, and also to generate a node.exe.ignore for each version that nodist downloads in the /v folder.

Please note that this doesn't fix what's being used by chocolatey at the moment. Hopefully the person who published the original chocolatey package can push these changes to chocolatey as well.
