### PR TITLE
Bash Script Fixes and Batch Script Modifications

### DIFF
--- a/bin/nodist
+++ b/bin/nodist
@@ -1,3 +1,2 @@
 #!/bin/sh
-DIR="`dirname \"$0\"`"
-"$DIR/../node.exe" "$DIR/../cli" $*
+`echo -n $COMSPEC | sed -e 's#\\\\#/#g'` '\/C' "$(which "${0}").cmd" $@


### PR DESCRIPTION
I hadn't really intended to make so many changes to the batch script, but an hour or so in, and this is where I found myself. That being said, if you'd like to accept some but not all of these changes, just let me know which parts you'd like me to revert. Anyways, I suppose it might help if I explain the reasoning for my modifications:
- **Variable Expansion/Case Sensitivity** - These changes were made in order to allow the script to still understand when the user specifies args in an unexpected way. (ex: `nodist "USE" "0.11.12"` - dumb, I know)
- **Self-Update Block Modifications** - I may have misunderstood something when I made these changes, so feel free to correct me if I'm wrong: In the original script, cmd was used to execute npm and nodist, but it do so with the unproven assumption that npm and nodist could both found on the user's `PATH`. This would fail in any cases where the user executed nodist using its filepath, and didn't have the bin folder on their `PATH`. On that assumption, I changed the this section so that all scripts are executed with their absolute filepath.
- **NPMRC Attribute Checks** - I'm probably the only person anal enough to do this, but to avoid having to stare at 20-30 dot files/folders every time I go to my HOME folder, I hide any new dot file that gets added. (and toggle visibility on the rare occasions that I need to get in there) Unfortunately, this causes npm to error out when it tries to access the hidden `.npmrc` file. In order to prevent this error, I added logic to the script to check for any attributes that would cause issues, remove them, and reapply them after npm finishes changing the user's configuration.
- **ERRORLEVEL** - This was only partially necessary in cases where the script should abort execution should one of the steps fail. (selfupdate for instance) Nonetheless, I went ahead and added error checking any time the script executes an action capable of failing.
- **:: -> REM** - Comments written using a blank label (`::`) have the potential to cause issues during execution. These issues most often arise in scripts that execute commands in blocks like this one, so I took some liberties and changed these pre-emptively. You can read a bit more on this in [this StackOverflow answer](http://stackoverflow.com/questions/12407800/which-comment-style-should-i-use-in-batch-files) and find some detailed information, including example code [on this site](http://www.robvanderwoude.com/comments.php).
- **NODIST_PREFIX** - I try to keep my defined environment variables to a minimum when possible. (at least as far as persistent environment variables go) Since the `NODIST_PREFIX` can easily be derived at the time of execution, I've gone ahead and had to script do so when it finds the prefix undefined.
- **NODIST_FORK_LEVEL** - This bit is probably pointless in this case, (pretty sure I was just fucking around by this point) but it's something I usually add whenever I write a self-executing batch script. Since the environment variables are localized to the script instance, each recursive execution of the script will increment the fork level by 1, and once the child script stops and execution is returned to the parent, the level returns to its original value. In its current form, this wont prevent any infinite recursion bug from occurring, but should one appear, would help to track and debug it.

You'll find a few annotations in comments in spots I wasn't sure about. (For instance: Why is `nodist add` executed twice? Is the second time just for the purpose of extracting the version number? (if so, I assume it returns immediately when it finds that noejs version already installed)

Lastly, I noticed open issue #63. I had originally intended to also include a shell script with my changes, but by the time I finished the changes to the batch script, I was pretty much over the whole thing. Still, I rewrote the script to a one-liner passing execution through the the batch script, which should hopefully resolve the issue until a shell script gets written. AS far as I know, which and sed are both included in every popular distribution of cygwin/msys, so there shouldn't be any issues with incompatiblities.
