### PR TITLE
escape npm prefix path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Nodist was designed to replace any existing node.js installation, so *if node is
 
 5. Run `nodist selfupdate` (updates the dependencies and sets npm's global prefix)
 
-6. `npm config set prefix %NODIST_PREFIX%\bin`
+6. `npm config set prefix "%NODIST_PREFIX%\bin"`
 
 ### Fancy installation (beta; discouraged)
 


### PR DESCRIPTION
If your `NODIST_PREFIX` contains a space (e.g. `C:\Program Files\nodist`) it will install your modules to `C:\Program\node_modules`
