### PR TITLE
fix #85 support for node 4.0

### DIFF
--- a/lib/nodist.js
+++ b/lib/nodist.js
@@ -103,7 +103,14 @@ nodist.prototype.getUrlToExe = function getUrlToExe(version) {
     return this.iojsSourceUrl+'/v'+version.substr('iojsv'.length)+(this.wantX64?'/win-x64':'/win-x86')+'/iojs.exe'
   }
   if(~version.indexOf('node')) {
-    return this.sourceUrl+'/v'+version.substr('nodev'.length)+(this.wantX64?'/x64':'')+'/node.exe'
+    var versionNumber = version.substr('nodev'.length);
+    if(versionNumber[0] === '0') {
+      // node 0.x
+      return this.sourceUrl+'/v'+versionNumber+(this.wantX64?'/x64':'')+'/node.exe'
+    } else {
+      // node 4.x and newer
+      return this.sourceUrl+'/v'+versionNumber+(this.wantX64?'/win-x64':'/win-x86')+'/node.exe'
+    }
   }
   return this.sourceUrl+'/v'+version+(this.wantX64?'/x64':'')+'/node.exe'
 }


### PR DESCRIPTION
Tested as follows:

```
me@mymachine /d/git/nodist
$ nodist 4
nodev4.0.0

me@mymachine /d/git/nodist
$ node --version
v4.0.0

me@mymachine /d/git/nodist
$ nodist 0.12
nodev0.12.7

me@mymachine /d/git/nodist
$ node --version
v0.12.7
```
