### PR TITLE
Address Issue with Incorrect NPM version in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,4 @@
 /.node-version
 node_modules
 /.idea
-/build/NodistSetup**
-/build/staging
-/build/tmp
-/build/Nodist.nsi
 /build/out

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 /build/staging
 /build/tmp
 /build/Nodist.nsi
+/build/out

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ MIT License
 
 ## Changelog
 
+v0.7.2
+* New build with the correct version of NPM
+
 v0.7.1
  * Fix x64 support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodist",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Natural node version manager for windows",
   "keywords": [
     "node",


### PR DESCRIPTION
I also cleaned up the gitignore to address some changes made by @marcelklehr 

I created a new build here: http://nodist.serverpals.com/

Direct link here: http://nodist.serverpals.com/NodistSetup-v0.7.2.exe

This comes with NPM @ 3.4.1 and Node.JS @ 5.1.0
