### PR TITLE
NPM Version Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 /.idea
 /build/out
+/npmv

--- a/README.md
+++ b/README.md
@@ -109,6 +109,46 @@ call nodist env 0.7.12
 # Displays a complete list of commands with examples.
 ```
 
+### NPM Version Management
+
+As of `v0.8.0` Nodist now implements NPM version management.
+
+The installation package is going to come with the latest NPM and the latest
+version of Node.
+
+Currently, Nodist does not offer any support for relating the version of NPM
+to Node.
+
+Version management is trivial
+
+```
+$ nodist npm
+//install latest version
+$ nodist npm latest
+//install latest version
+$ nodist npm 2.x
+//install latest 2.x version
+$ nodist npm 3.3.x
+//latest in the 3.3 branch
+$ nodist npm 3.4.1
+//install version 3.4.1
+```
+
+The copies of NPM are saved to the `npmv` folder of the local Nodist install.
+If any errors occur during download. These files might prevent the version
+manager from using a complete installation. To remove a version use the
+following.
+
+```
+$ nodist npm remove 3.4.1
+//only accepts exact versions
+//removed version 3.4.1
+//now to reinstall
+$ nodist npm 3.4.1
+```
+
+Enjoy!
+
 ### Settings
 
 ```
@@ -179,10 +219,17 @@ $ DEBUG=nodist node app
 ```
 
 ## Legal
-Copyright (c) 2012-2014 by Marcel Klehr  
+Copyright (c) 2012-2016 by Marcel Klehr  
 MIT License
 
 ## Changelog
+
+v0.8.0
+* Add NPM version management
+* Improve build scripting in regards to NPM downloads
+* Implement NPM helper library
+* Implement GitHub API to iterate NPM installation
+* Bump Copyright year
 
 v0.7.2
 * New build with the correct version of NPM

--- a/build/Nodist.template.nsi
+++ b/build/Nodist.template.nsi
@@ -7,7 +7,7 @@
 !define APP_NAME "Nodist"
 !define COMP_NAME "Nodist"
 !define WEB_SITE "https://github.com/marcelklehr/nodist"
-!define VERSION "0.7.0.0"
+!define VERSION ";VERSION;.0"
 !define COPYRIGHT "Marcel Klehr  ? 2015"
 !define DESCRIPTION "Node Version Manager for Windows"
 !define LICENSE_TXT "staging\LICENSE.txt"
@@ -116,6 +116,8 @@ SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=50
 AccessControl::GrantOnFile "$INSTDIR" "(BU)" "FullAccess"
 ; set the NPM prefix
 Exec '"$INSTDIR\node.exe" "$INSTDIR\bin\node_modules\npm\bin\npm-cli.js" config set prefix "$INSTDIR\bin"'
+; run the selfupdate
+Exec '"$INSTDIR\bin\nodist.cmd" "selfupdate"'
 SectionEnd
 
 ######################################################################

--- a/cli.js
+++ b/cli.js
@@ -26,6 +26,7 @@
 
 var version = process.argv[2];
 var nodist = require('./lib/nodist');
+var npm = require('./lib/npm');
 var path = require('path');
 var fs = require('fs');
 
@@ -77,7 +78,7 @@ var proxy = (
   process.env.https_proxy ||
   ''
 );
-var wantX64 = process.env.NODIST_X64 == 1;
+var wantX64 = (+process.env.NODIST_X64) === 1;
 var envVersion = process.env.NODIST_VERSION ?
   process.env.NODIST_VERSION.replace(/"/g, '') : process.env.NODIST_VERSION;
 
@@ -173,6 +174,32 @@ else if (command.match(/^dist|ds$/i)) {
     if(n.proxy) console.log('\n  (Proxy: ' + n.proxy + ')');
     exit();
   });
+}
+//NPM version management
+else if (command.match(/^npm/i)){
+  //so now what shall we do with npm, we probably want something like
+  //'latest' and then 'version' with similar version parsing to node version
+  version = argv[1];
+  if('remove' === version){
+    version = argv[2];
+    npm.resolveVersion(version, function(er, v){
+      if(er) abort(er.message+'. Sorry.');
+      console.log('Resolved NPM version to ' + v);
+      npm.remove(v,function(err,v){
+        if(err) abort(err.message + '. Sorry.');
+        console.log('NPM ' + v + ' removed!');
+      });
+    });
+  } else {
+    npm.resolveVersion(version, function(er, v) {
+      if(er) abort(er.message+'. Sorry.');
+      console.log('Resolved NPM version to ' + v);
+      npm.install(v, function(err, v) {
+        if(err) abort(err.message+'. Sorry.');
+        console.log('NPM ' + v + ' installed and in use!');
+      });
+    });
+  }
 }
 // ADD fetch a specific build
 else if ((command.match(/^add|\+$/i)) && argv[1]) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -42,18 +42,32 @@ exports.copyFile = function copyFile(source, target, cb){
  * @param {string} url
  * @param {string} dest
  * @param {function} cb
+ * @param {number} loopCount  only used to prevent redirect loops looking for
+ *   content length
  */
-exports.downloadFile = function downloadFile(url, dest, cb){
+exports.downloadFile = function downloadFile(url, dest, cb, loopCount){
   dest = path.resolve(dest);
   var file = fs.createWriteStream(dest);
   var progress = {};
   var fileSize = 1;
-  var req = request.get(url);
+  var req = request({url: url});
   req.on('response',function(res){
     if(res.statusCode !== 200){
       cb(new Error('Failed to read response from ' + url));
+    } else if(!res.headers['content-length']){
+      if(!loopCount) loopCount = 0;
+      if(loopCount < 5){
+        loopCount++;
+        console.log(
+          'Failed to find content length on ' + url + ' retry ' + loopCount);
+        return downloadFile(url,dest,cb);
+      } else {
+        cb(new Error('Too many redirects looking for content length'));
+      }
     } else {
-      fileSize = Math.round(res.headers['content-length'] / 1024);
+      var fileSize = Math.round(
+        ((+res.headers['content-length']) || 3145728) / 1024
+      );
       progress = new ProgressBar(
         path.basename(dest) +
         ' [:bar] :current/:total KiB :rate/Kbps :percent :etas',
@@ -67,7 +81,8 @@ exports.downloadFile = function downloadFile(url, dest, cb){
     }
   });
   req.on('data',function(chunk){
-    progress.tick(Math.round(chunk.length / 1024));
+    if(progress && 'function' === typeof progress.tick)
+      progress.tick(Math.round(chunk.length / 1024));
   });
   promisePipe(req,file).then(function(){
     progress.update(1,fileSize);

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,0 +1,21 @@
+'use strict';
+var GithubApi = require('github');
+
+var github = new GithubApi({
+  version: '3.0.0'
+});
+
+//do some auth
+github.authenticate({
+  type: 'oauth',
+  //this is a key i made for @nullivex that has no special privileges it simply
+  //increases the api limit, please do not abuse it :(
+  token: 'f0150031de4ef62c5f7f38c5358c7cfc3785a595'
+});
+
+
+/**
+ * Github API instance
+ * @type {module.exports|exports}
+ */
+module.exports = github;

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,0 +1,209 @@
+'use strict';
+var P = require('bluebird');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var ncp = require('ncp');
+var path = require('path');
+var promisePipe = require('promisepipe');
+var rimraf = require('rimraf');
+var semver = require('semver');
+var unzip = require('unzip');
+
+var buildHelper = require('./build');
+var github = require('./github');
+
+//make some promises
+P.promisifyAll(buildHelper);
+P.promisifyAll(fs);
+P.promisifyAll(github);
+P.promisifyAll(github.releases);
+P.promisifyAll(github.repos);
+mkdirp = P.promisify(mkdirp);
+ncp = P.promisify(ncp);
+rimraf = P.promisify(rimraf);
+
+//define where we store our npms
+var npmRepoPath = path.resolve(path.join(__dirname,'..','npmv'));
+var npmProdPath = path.resolve(
+  path.join(__dirname,'..','bin','node_modules','npm'));
+
+
+/**
+ * List available NPM versions
+ * @return {string}
+ */
+exports.listAvailable = function(){
+  return github.releases.listReleasesAsync({
+    owner: 'npm',
+    repo: 'npm',
+    per_page: '100'
+  });
+};
+
+
+/**
+ * Get latest NPM version
+ * @return {string}
+ */
+exports.latestVersion = function(){
+  return github.releases.getLatestReleaseAsync({
+      owner: 'npm',
+      repo: 'npm'
+    })
+    .then(function(result){
+      return result.tag_name;
+    });
+};
+
+
+/**
+ * Get a download URL for the version
+ * @param {string} version
+ * @return {string}
+ */
+exports.downloadUrl = function(version){
+  return 'https://codeload.github.com/npm/npm/zip/vVERSION'
+    .replace('VERSION',version.replace('v',''));
+};
+
+
+/**
+ * Resolve a version from a string
+ * @param {string} v
+ * @param {function} done
+ */
+exports.resolveVersion = function(v,done){
+  P.all([
+    exports.listAvailable(),
+    exports.latestVersion()
+  ])
+    .then(function(results){
+      var latestVersion = results[1];
+      var available = results[0].map(function(v){
+        return v.tag_name;
+      });
+      //correct latest version if used
+      if('latest' === v || !v){
+        v = latestVersion;
+      }
+      //try to get a version if its explicit
+      var version = semver.clean(v);
+      //support version ranges
+      if(semver.validRange(v)){
+        version = semver.maxSatisfying(available,v);
+      }
+      done(null,version);
+    })
+    .catch(function(err){
+      done(err);
+    });
+};
+
+
+/**
+ * Use a version of NPM
+ * @param {string} v
+ * @param {function} done
+ * @return {*}
+ */
+exports.use = function(v,done){
+  var version = semver.clean(v);
+  if(!semver.valid(version)) return done(new Error('Invalid version'));
+  var archivePath = path.resolve(
+    path.join(npmRepoPath,version,'npm-' + version)
+  );
+  //make sure we have the current version in the repo it should already be
+  //installed
+  if(!fs.existsSync(archivePath))
+    return done(new Error('Version not installed'));
+  //we can go ahead and nuke the old version
+  rimraf(npmProdPath)
+    .then(function(){
+      //now copy the new version in
+      return ncp(archivePath,npmProdPath);
+    })
+    .then(function(){
+      done(null,version);
+    })
+    .catch(function(err){
+      done(err);
+    });
+};
+
+
+/**
+ * Remove a version of NPM
+ * @param {string} v
+ * @param {function} done
+ * @return {*}
+ */
+exports.remove = function(v, done){
+  var version = semver.clean(v);
+  if(!semver.valid(version)) return done(new Error('Invalid version'));
+  var zipFile = path.resolve(path.join(npmRepoPath,version + '.zip'));
+  var archivePath = path.resolve(path.join(npmRepoPath,version));
+
+  //check if this version is already installed, if so just use it
+  if(!fs.existsSync(archivePath) && !fs.existsSync(zipFile)){
+    return done(null,version);
+  }
+
+  //nuke everything for this version
+  P.all([rimraf(archivePath),rimraf(zipFile)])
+    .then(function(){
+      done(null,version);
+    })
+    .catch(function(err){
+      done(err);
+    });
+};
+
+
+/**
+ * Install NPM version or use it if already installed
+ * @param {string} v
+ * @param {function} done
+ * @return {*}
+ */
+exports.install = function(v,done){
+  var version = semver.clean(v);
+  if(!semver.valid(version)) return done(new Error('Invalid version'));
+  var zipFile = path.resolve(path.join(npmRepoPath,version + '.zip'));
+  var archivePath = path.resolve(path.join(npmRepoPath,version));
+
+  //check if this version is already installed, if so just use it
+  if(fs.existsSync(archivePath) && fs.existsSync(zipFile)){
+    return exports.use(version,done);
+  }
+
+  //otherwise install the new version
+  P.all([
+      mkdirp(npmProdPath),
+      mkdirp(npmRepoPath),
+      mkdirp(archivePath)
+  ])
+    .then(function(){
+      var downloadLink = exports.downloadUrl(version);
+      //download tarball i think, i am going to steal this from the build script
+      console.log(
+        'Downloading NPM from ' + downloadLink + ' to ' + zipFile);
+      return buildHelper.downloadFileAsync(downloadLink,zipFile);
+    })
+    .then(function(){
+      return mkdirp(path.dirname(archivePath));
+    })
+    .then(function(){
+      //now actually extract the zip files
+      return promisePipe(
+        fs.createReadStream(zipFile).
+        pipe(unzip.Extract({ path: archivePath }))
+      );
+    })
+    .then(function(){
+      //the last thing to do is to use the version
+      exports.use(version,done);
+    })
+    .catch(function(err){
+      done(err);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodist",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Natural node version manager for windows",
   "keywords": [
     "node",
@@ -22,6 +22,7 @@
   "dependencies": {
     "bluebird": "^2.10.2",
     "debug": "^2.2.0",
+    "github": "nullivex/node-github",
     "mkdirp": "~0.5",
     "ncp": "^2.0.0",
     "progress": "nullivex/node-progress",
@@ -29,7 +30,7 @@
     "recursive-readdir": "^1.2.1",
     "request": "~2.65",
     "rimraf": "~2",
-    "semver": "*",
+    "semver": "^5.1.0",
     "unzip": "^0.1.11"
   },
   "devDependencies": {


### PR DESCRIPTION
This will complete what I would deem to be a stable 0.8.0.

It comes complete with.
- Add NPM version management
- Improve build scripting in regards to NPM downloads
- Implement NPM helper library
- Implement GitHub API to iterate NPM installation
- Bump Copyright year

You can see more in the README on usage.

Here is my console output on a fresh install.

```
C:\Users\Mac>node -v
v5.3.0

C:\Users\Mac>npm -v
3.5.2

C:\Users\Mac>nodist
  (x64)
  5.3.0

C:\Users\Mac>nodist npm
Resolved NPM version to v3.5.2
NPM 3.5.2 installed and in use!

C:\Users\Mac>nodist npm 3.3.6
Resolved NPM version to v3.3.6
Downloading NPM from https://codeload.github.com/npm/npm/zip/v3.3.6 to C:\Progra
m Files (x86)\Nodist\npmv\3.3.6.zip
Failed to find content length on https://codeload.github.com/npm/npm/zip/v3.3.6
retry 1
3.3.6.zip [===============] 4139/4139 KiB 1274/Kbps 100% 0.0s
NPM 3.3.6 installed and in use!

C:\Users\Mac>npm -v
3.3.6

C:\Users\Mac>nodist npm 3.5.1
Resolved NPM version to v3.5.1
Downloading NPM from https://codeload.github.com/npm/npm/zip/v3.5.1 to C:\Progra
m Files (x86)\Nodist\npmv\3.5.1.zip
Failed to find content length on https://codeload.github.com/npm/npm/zip/v3.5.1
retry 1
3.5.1.zip [===============] 4550/4550 KiB 1479/Kbps 100% 0.0s
NPM 3.5.1 installed and in use!

C:\Users\Mac>npm -v
3.5.1

C:\Users\Mac>nodist npm remove 3.3.6
Resolved NPM version to v3.3.6
NPM 3.3.6 removed!
```

Happy Holidays!
