### PR TITLE
Treat io.js versions as node versions, since the version spectrum is a continuum

### DIFF
--- a/lib/nodist.js
+++ b/lib/nodist.js
@@ -85,6 +85,15 @@ nodist.prototype.setWantX64 = function(wantX64) {
   this.wantX64 = !!wantX64;
 };
 
+nodist.isIojs = function(version) {
+  var major = parseInt(version.split('.')[0])
+  return (major >= 1 && major < 4)
+}
+
+nodist.isZeroVersion = function(version) {
+  var major = parseInt(version.split('.')[0])
+  return (major == 0)
+}
 
 /**
  * Determine the version of the passed node exe
@@ -155,12 +164,10 @@ nodist.prototype.getPathToGlobalVersion = function getPathToGlobalVersion(){
 nodist.prototype.getRelativePathToExe = function getRelativePathToExe(version){
   //this default reflects node 4+ which is most likely to be what is used now
   var dir = (this.wantX64 ? 'win-x64/' : 'win-x86/') + 'node.exe';
-  if(~version.indexOf('iojs')){
+  if(nodist.isIojs(version)){
     dir = (this.wantX64 ? 'win-x64/' : 'win-x86/') + 'iojs.exe';
-  }
-  if(~version.indexOf('node')) {
-    var versionNumber = version.substr('nodev'.length);
-    if(versionNumber[0] === '0') {
+  } else {
+    if(nodist.isZeroVersion(version)) {
       // node 0.x
       dir = (this.wantX64 ? 'x64/' : '') + 'node.exe';
     } else {
@@ -180,12 +187,10 @@ nodist.prototype.getRelativePathToExe = function getRelativePathToExe(version){
  */
 nodist.prototype.getSourceUrlPrefix = function getSourceUrlPrefix(version){
   var url = this.sourceUrl + '/v' + version;
-  if(~version.indexOf('iojs')) {
-    url = this.iojsSourceUrl + '/v' + version.substr('iojsv'.length);
-  }
-  if(~version.indexOf('node')) {
-    var versionNumber = version.substr('nodev'.length);
-    url = this.sourceUrl + '/v' + versionNumber;
+  if(nodist.isIojs(version)) {
+    url = this.iojsSourceUrl + '/v' + version;
+  }else {
+    url = this.sourceUrl + '/v' + version;
   }
   debug('getSourceUrlPrefix',url);
   return url;
@@ -279,7 +284,7 @@ nodist.prototype.fetchAvailable = function fetchAvailable(sourceUrl, name, cb){
       if(err) return cb(err);
       var versionResult = JSON.parse(body)
         .map(function(v){
-          return name + v.version;
+          return v.version;
         })
         .sort(function(v1,v2){
           if(vermanager.compareable(v1) > vermanager.compareable(v2)){

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -13,7 +13,6 @@ var versions = module.exports;
 */
 versions.compareable = function compareable(ver){
   if(~ver.indexOf('iojs')) ver = ver.substr('iojsv'.length);
-  if(~ver.indexOf('node')) ver = ver.substr('nodev'.length);
   var parts = ver.split('.');
   return +parts.map(
     function(d){
@@ -35,58 +34,22 @@ versions.compareable = function compareable(ver){
  */
 versions.find = function(versionSpec, list, cb){
   var v, i = list.length-1;
-  if(versionSpec.match(/^(node-?stable|stable-?node|stable)$/i)) {
-    if(i >= 0){
-      do {
-        v = list[i--];
-      }
-      while(
-        v && (!~v.indexOf('node') ||
-        parseInt(v.substr('nodev'.length).split('.')[1]) % 2 !== 0) && i >= 0
-      );// search for an even number: e.g. 0.2.0
-    }
-  } else if(versionSpec.match(/^(latest-?node|node-?latest|latest)$/i)){
+  if(versionSpec.match(/^(latest)$/i)){
     v = list
-    .filter(function(v) { return !!~v.indexOf('node'); })
     .reduce(function(v1, v2) {
       return versions.compareable(v1) > versions.compareable(v2)? v1 : v2;
     }, '0.0.0');
-  } else if(versionSpec.match(/^(latest-?iojs|iojs-?latest)$/i)){
-    v = list
-    .filter(function(v) { return !!~v.indexOf('iojs'); })
-    .reduce(function(v1, v2) {
-      return versions.compareable(v1) > versions.compareable(v2)? v1 : v2;
-    }, '0.0.0');
-  } else if(~versionSpec.indexOf('iojs')){
-    versionSpec = versionSpec.substr('iojsv'.length);
-    if(i >= 0){
-      do { v = list[i--]; }
-      while(
-        v && (!~v.indexOf('iojs') ||
-        !semver.satisfies(v.substr('iojsv'.length), versionSpec)) && i >= 0
-      );
-    }
-    if(
-      !semver.satisfies(v.substr('iojsv'.length), versionSpec) ||
-      !~v.indexOf('iojs')
-    ){
-      v = null;
-    }
   } else {
-    if(~versionSpec.indexOf('node')){
-      versionSpec = versionSpec.substr('nodev'.length);
-    }
     if(i >= 0){
       do { v = list[i--]; }
       while(
-        v && (!~v.indexOf('node') ||
-        !semver.satisfies(v.substr('nodev'.length), versionSpec)) && i >= 0
+        v && (!semver.satisfies(v, versionSpec)) && i >= 0
       );
     }
-    if(v && !semver.satisfies(v.substr('nodev'.length), versionSpec)) v = null;
+    if(v && !semver.satisfies(v, versionSpec)) v = null;
   }
   if(!v || v === '0.0.0')
     return cb(new Error('Version spec, "' +
-      versionSpec + '", didn\'t match any available version'));
+      versionSpec + '", didn\'t match any version'));
   cb(null, v);
 };


### PR DESCRIPTION
I threw out a whole lot of ugly code to get back simple version numbers instead of the whole mess with converting back and forth between `nodev5.2.0` and `5.2.0`.

Io.js is now treated as a node version, since that's made possible by the continuous version spectrum.

Let me know what you think :)
