### PR TITLE
Compatibility with nodenv (nodist for OS-X/Linux)

### DIFF
--- a/lib/nodist.js
+++ b/lib/nodist.js
@@ -266,7 +266,13 @@ nodist.prototype.getCurrentVersion = function(cb) {
             this.resolveVersionLocally(envSpec, (er6, envVersion) => {
               if (er1 || er2 || er3 || er4 || er5 || er6) // I'l use promises next time. I promise.
                 return cb(er1 || er2 || er3 || er4 || er5 || er6)
-              cb(null, envVersion || localVersion || globalVersion)
+              var currentVersion = envVersion || localVersion || globalVersion
+              // Ensure compatibility with nodenv .node_version files
+              // which does not add a `v` in front of the version
+              if (typeof currentVersion === 'string' && currentVersion.substr(0, 1) !== 'v') {
+                currentVersion = 'v' + currentVersion
+              }
+              cb(null, currentVersion)
             })
           })
         })


### PR DESCRIPTION
[nodenv](https://github.com/nodenv/nodenv) is doing the same thing that nodist does but for OS-X/Linux.

As our teams consists of Windows, OS-X and Linux users we would like to work with both tools in the same projects.

Unfortunately nodist and nodenv use the same file name `.node-version` but different notations.

Nodenv: `4.4.4`
Nodist: `v4.4.4`

This pull request adds the missing `v` when reading in the `.node-version` file so that nodist won't crash if the v is missing.

Please let me know what you think about it
