### PR TITLE
Fix: before using tick or update, check they exist and are functions

### DIFF
--- a/lib/nodist.js
+++ b/lib/nodist.js
@@ -647,7 +647,9 @@ nodist.prototype.fetch = function fetch(version, callback){
           (err ? err.message : 'HTTP '+resp.statusCode)
         ));
       }
-      bar.update(1,Math.round(binarySize / 1024));
+      if (bar.hasOwnProperty('update') && typeof bar.update === 'function') {
+      	bar.update(1,Math.round(binarySize / 1024));
+      }
       debug('fetch','binary download complete');
       //here we want to get the shasum text and then get the
       // actual sum from that file
@@ -715,7 +717,9 @@ nodist.prototype.fetch = function fetch(version, callback){
   });
   //update progress bar
   stream.on('data',function(chunk){
-    bar.tick(Math.round(chunk.length / 1024));
+    if (bar.hasOwnProperty('tick') && typeof bar.tick === 'function') {
+      bar.tick(Math.round(chunk.length / 1024));
+    }
   });
   //handle errors
   stream.on('error', function(err){


### PR DESCRIPTION
in `0.8.0-rc4` these two lines are not functions, because `stream.on('response'....` never gets called.

Since the progress bar is a cosmetic feature and not essential to the operation of nodist I'll leave fixing why the response event isn't happening to someone who cares.

More important is that nodist actually works.
Fixes: #139 
