### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "progress": "1.x",
     "promisepipe": "^1.0.1",
     "recursive-readdir": "^1.2.1",
-    "request": "~2.65",
+    "request": "~2.74.0",
     "rimraf": "~2",
     "semver": "^5.1.0",
     "tar": "2.x"


### PR DESCRIPTION
nodist currently has a 2 vulnerable dependency, introducing 3 different types of known vulnerabilities.

[ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency and [remote memory exposure](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/marcelklehr/nodist) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all  the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `recursive-readdir` dependency as well.

Stay Secure,
The Snyk Community
