### PR TITLE
fix suppressed error bug

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -364,6 +364,7 @@ else if (command.match(/^global$/i) && argv[1] || argv[0] && !argv[1]) {
         exit();
       }
       n.resolveVersion(spec, function(er, version) {
+        if(er) return abort(er.message+'. Sorry.')
         console.log("Installing "+version)
         n.install(version, function(er) {
           if(er) return abort(er.message+'. Sorry.')

--- a/cli.js
+++ b/cli.js
@@ -356,11 +356,11 @@ else if (command.match(/^local$/i) && argv[1]) {
 // GLOBAL globally use the specified node version
 else if (command.match(/^global$/i) && argv[1] || argv[0] && !argv[1]) {
   spec = argv[1] || argv[0];
-  if(err) abort(err.message+'. Sorry.');
   console.log(spec);
   n.resolveVersionLocally(spec, function(er, found) {
     if(found) {
       return n.setGlobal(spec, function(err) {
+	if(err) abort(err.message+'. Sorry.')
         exit(0, 'Default global pacakge update dsuccessful.')
       })
     }
@@ -370,6 +370,7 @@ else if (command.match(/^global$/i) && argv[1] || argv[0] && !argv[1]) {
       n.install(version, function(er) {
         if(er) return abort(er.message+'. Sorry.')
         n.setGlobal(spec, function(err) {
+	  if(err) abort(err.message+'. Sorry.')
           exit(0, 'Installation successful.')
         })
       })

--- a/cli.js
+++ b/cli.js
@@ -360,7 +360,10 @@ else if (command.match(/^global$/i) && argv[1] || argv[0] && !argv[1]) {
   console.log(spec);
   n.resolveVersionLocally(spec, function(er, found) {
     if(found) {
-      exit();
+      n.setGlobal(spec, function(err) {
+        exit(0, 'Default global pacakge update dsuccessful.')
+      });
+      return;
     }
     n.resolveVersion(spec, function(er, version) {
       if(er) return abort(er.message+'. Sorry.')

--- a/cli.js
+++ b/cli.js
@@ -360,10 +360,9 @@ else if (command.match(/^global$/i) && argv[1] || argv[0] && !argv[1]) {
   console.log(spec);
   n.resolveVersionLocally(spec, function(er, found) {
     if(found) {
-      n.setGlobal(spec, function(err) {
+      return n.setGlobal(spec, function(err) {
         exit(0, 'Default global pacakge update dsuccessful.')
-      });
-      return;
+      })
     }
     n.resolveVersion(spec, function(er, version) {
       if(er) return abort(er.message+'. Sorry.')

--- a/cli.js
+++ b/cli.js
@@ -356,24 +356,23 @@ else if (command.match(/^local$/i) && argv[1]) {
 // GLOBAL globally use the specified node version
 else if (command.match(/^global$/i) && argv[1] || argv[0] && !argv[1]) {
   spec = argv[1] || argv[0];
-  n.setGlobal(spec, function(err) {
-    if(err) abort(err.message+'. Sorry.');
-    console.log(spec);
-    n.resolveVersionLocally(spec, function(er, found) {
-      if(found) {
-        exit();
-      }
-      n.resolveVersion(spec, function(er, version) {
+  if(err) abort(err.message+'. Sorry.');
+  console.log(spec);
+  n.resolveVersionLocally(spec, function(er, found) {
+    if(found) {
+      exit();
+    }
+    n.resolveVersion(spec, function(er, version) {
+      if(er) return abort(er.message+'. Sorry.')
+      console.log("Installing "+version)
+      n.install(version, function(er) {
         if(er) return abort(er.message+'. Sorry.')
-        console.log("Installing "+version)
-        n.install(version, function(er) {
-          if(er) return abort(er.message+'. Sorry.')
+        n.setGlobal(spec, function(err) {
           exit(0, 'Installation successful.')
         })
       })
     })
-
-  });
+  })
 }
 // HELP display help for unknown cli parameters
 else {


### PR DESCRIPTION
Scenario:
 - run nodist with a non-existing version
e.g. `nodist  6.7.1`

Expect:
 - a friendly error, telling the verison is not found

Found: 
```
C:\Nodist\lib\nodist.js:89
  var major = parseInt(version.split('.')[0])
                              ^

TypeError: Cannot read property 'split' of undefined
    at Function.nodist.isIojs (C:\Nodist\lib\nodist.js:89:31)
    at nodist.getSourceUrlPrefix (C:\Nodist\lib\nodist.js:190:13)
    at nodist.getUrlToExe (C:\Nodist\lib\nodist.js:206:18)
    at nodist.fetch (C:\Nodist\lib\nodist.js:587:18)
    at C:\Nodist\lib\nodist.js:497:10
    at C:\Nodist\lib\nodist.js:417:7
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```


After the fix, expect:
```
Version spec, "6.7.1", didn't match any version.
Sorry.
```