### PR TITLE
Various fixes and changes to npm commands

### DIFF
--- a/bin/nodist.sh
+++ b/bin/nodist.sh
@@ -13,7 +13,7 @@ nodist() {
             res=`"$NODIST_BIN_DIR__/nodist" + "$2"`
             ret=$?
             if [ $ret -eq 0 ]; then
-                export NODIST_NODE_VERSION=$res
+                export NODIST_NODE_VERSION=$2
             fi
             echo $res
         fi
@@ -22,10 +22,10 @@ nodist() {
             echo "Please specify a version to use."
             ret=1
         else
-            res=`"$NODIST_BIN_DIR__/nodist" npm + "$2"`
+            res=`"$NODIST_BIN_DIR__/nodist" npm + "$3"`
             ret=$?
             if [ $ret -eq 0 ]; then
-                export NODIST_NPM_VERSION=$res
+                export NODIST_NPM_VERSION=$3
             fi
             echo $res
         fi

--- a/cli.js
+++ b/cli.js
@@ -194,10 +194,11 @@ else if (command.match(/^npm$/i)){
       if(er) abort(er.message+'. Sorry.');
       npm.install(v,function(err,v){
         if(err) abort(err.message + '. Sorry.');
+        console.log(v);
       });
     });
   } else
-  if(subcmd.match(/^remove$/i)){
+  if(subcmd.match(/^remove|\-$/i)){
     version = argv[2];
     npm.resolveVersionLocally(version, function(er, v){
       if(er) abort(er.message+'. Sorry.');
@@ -247,7 +248,7 @@ else if (command.match(/^npm$/i)){
     version = argv[2];
     npm.setLocal(version, function(er){
       if(er) abort(er.message+'. Sorry.');
-      npm.resolveVersion(version, function(er, v) {	
+      npm.resolveVersion(version, function(er, v) {
 	if(er) abort(er.message + '. Sorry.');
 	npm.install(v,function(err,v){
 	  if(er) abort(er.message + '. Sorry.');

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -130,7 +130,7 @@ NPMIST.downloadUrl = function(version){
 
 NPMIST.resolveVersionLocally = function(spec, done) {
   if (!spec) return done()
-  this.listInstalled((er, installed) => { 
+  this.listInstalled((er, installed) => {
     if (spec === 'latest') return done(null, installed[0])
 
     if (spec === 'match') {
@@ -190,6 +190,10 @@ NPMIST.resolveVersion = function(v,done){
     if(semver.validRange(v)){
       version = semver.maxSatisfying(available,v);
     }
+    if (!version) {
+      done(new Error('Version spec, "' + v + '", didn\'t match any version'));
+      return;
+    }
     done(null,version);
   })
   .catch(function(err){
@@ -234,14 +238,14 @@ NPMIST.install = function(v,done){
   debug('install', v)
   var version = semver.clean(v);
   if(!semver.valid(version)) return done(new Error('Invalid version'));
-  
+
   var zipFile = path.resolve(path.join(this.repoPath,version + '.zip'));
   var archivePath = path.resolve(path.join(this.repoPath,version));
 
   //check if this version is already installed, if so just bail
   if(fs.existsSync(archivePath)){
     debug('install', 'this version is already installed')
-    return done()
+    return done(null, version)
   }
 
   //otherwise install the new version
@@ -250,7 +254,7 @@ NPMIST.install = function(v,done){
   .then(() => {
     var downloadLink = NPMIST.downloadUrl(version);
     debug('Downloading and extracting NPM from ' + downloadLink);
-    
+
     return new Promise((resolve, reject) => {
       buildHelper.downloadFileStream(downloadLink)
       .pipe(zlib.createUnzip())
@@ -263,7 +267,7 @@ NPMIST.install = function(v,done){
     })
   })
   .then(() => {
-    done()
+    done(null, version)
   })
   .catch((err) => {
     done(err);


### PR DESCRIPTION
- Fixed nodist.sh typo (was sending the incorrect argument to `nodist npm +`)
- In nodist.sh `NODIST_NPM_VERSION` and `NODIST_NODE_VERSION` are now set from arguments, like in nodist.cmd
- When installing an npm version, version number is now output, like with a node version install
- Added `-` as an alias for `remove` subcommand for npm command
- Added an error message when attempting to install a version of npm that doesn't exist