### PR TITLE
fix(npm ls): resolve to correct version

### DIFF
--- a/src/lib/nodist/nodist.go
+++ b/src/lib/nodist/nodist.go
@@ -131,7 +131,7 @@ func resolveVersion(spec string, installed []*semver.Version) (version string, e
   }
 
   if spec == "latest" {
-    version = installed[0].String()
+    version = installed[len(installed)-1].String()
   }else{
     for _, v := range installed {
       debug("checking %s against %s", v.String(), spec)


### PR DESCRIPTION
When spec is "latest", resolveVersion resolves to most **oldest** version.

```
> nodist npm latest

> nodist npm use latest

> nodist npm ls
> 4.0.5  (global: latest)
  4.6.1
  5.4.2

> npm -v                                                                                                         
03:57:01.151 0ns    0ns    nodist:shim - getTargetEngine: targetDir: C:\Program Files (x86)\Nodist               
03:57:01.152 0ns    0ns    nodist:shim - getTargetEngine: ReadFile C:\Program Files (x86)\Nodist\package.json    
03:57:01.152 0ns    0ns    nodist:shim - parsePackageJSON: {Engines:{Npm: Node:}}                                
03:57:01.153 1ms    1ms    nodist:shim - Global file found: '8.5.0'                                              
03:57:01.153 0ns    0ns    nodist:shim - checking 8.5.0 against 8.5.0                                            
03:57:01.154 3ms    3ms    nodist:shim-npm - determined node version: 8.5.0                                      
03:57:01.154 0ns    0ns    nodist:shim - getTargetEngine: targetDir: C:\Program Files (x86)\Nodist               
03:57:01.154 0ns    0ns    nodist:shim - getTargetEngine: ReadFile C:\Program Files (x86)\Nodist\package.json    
03:57:01.154 0ns    0ns    nodist:shim - parsePackageJSON: {Engines:{Npm: Node:}}                                
03:57:01.155 0ns    0ns    nodist:shim - Global file found: 'latest'                                             
03:57:01.156 2ms    2ms    nodist:shim-npm - current npm version spec: latest                                    
03:57:01.156 0ns    0ns    nodist:shim-npm - determined npm version: 5.4.2                                       
5.4.2                                                                                                            
```

![img](https://pbs.twimg.com/media/DKYN-GyV4AUQzNW?format=jpg)