### PR TITLE
fix:  npm download url

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -124,7 +124,7 @@ NPMIST.matchingVersion = function(){
  * @return {string}
  */
 NPMIST.downloadUrl = function(version){
-  return 'https://codeload.github.com/npm/npm/tar.gz/vVERSION'
+  return 'https://codeload.github.com/npm/cli/tar.gz/vVERSION'
     .replace('VERSION',version.replace('v',''));
 };
 


### PR DESCRIPTION
npm repository is moving to: https://github.com/npm/cli

from v6.2.0 we can't download archive file from old npm repository 