### PR TITLE
fixes #219 - installs well npm higher than 6.1.x

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -45,11 +45,19 @@ var NPMIST = npmist.prototype
  * @return {string}
  */
 NPMIST.listAvailable = function(){
-  return github.releases.listReleasesAsync({
-    owner: 'npm',
-    repo: 'npm',
-    per_page: '100'
-  });
+  return Promise.all([
+    github.releases.listReleasesAsync({
+      owner: 'npm',
+      repo: 'npm',
+      per_page: '100'
+    }),
+    github.releases.listReleasesAsync({
+      owner: 'npm',
+      repo: 'cli',
+      per_page: '100'
+    })
+  ])
+  .then(([npm, cli]) => npm.concat(cli));
 };
 
 /**
@@ -124,7 +132,7 @@ NPMIST.matchingVersion = function(){
  * @return {string}
  */
 NPMIST.downloadUrl = function(version){
-  return 'https://codeload.github.com/npm/npm/tar.gz/vVERSION'
+  return 'https://codeload.github.com/npm/cli/tar.gz/vVERSION'
     .replace('VERSION',version.replace('v',''));
 };
 


### PR DESCRIPTION
While downloads have redirection from `/npm/npm` to `/npm/cli`, listing available versions brings only versions published on the repo.

So we need to download from /npm/cli, but validate versions against both.