### PR TITLE
No longer use Github authentication with making API calls.

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -5,14 +5,17 @@ var github = new GithubApi({
   version: '3.0.0'
 });
 
-//do some auth
-github.authenticate({
+// -------------------------
+// Github Authentication
+//-------------------------
+var githubCredentials = {
   type: 'oauth',
-  //this is a key i made for @nullivex that has no special privileges it simply
-  //increases the api limit, please do not abuse it :(
-  token: 'f0150031de4ef62c5f7f38c5358c7cfc3785a595'
-});
-
+  // in order to raise your API limits place a token here generated from github
+  // then remove the comment below
+  token: 'xxx'
+};
+// remove the comment at the beginning of the line below to activate auth
+// github.authenticate(githubCredentials);
 
 /**
  * Github API instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,9 +120,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -332,9 +332,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.3.5",
@@ -354,11 +354,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -505,6 +505,21 @@
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "tough-cookie": {
@@ -560,12 +575,12 @@
       }
     },
     "vows": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/vows/-/vows-0.8.2.tgz",
-      "integrity": "sha1-aR95qybM3oC6cm3en+yOc9a88us=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.8.3.tgz",
+      "integrity": "sha512-PVIxa/ovXhrw5gA3mz6M+ZF3PHlqX4tutR2p/y9NWPAaFVKcWBE8b2ktfr0opQM/qFmcOVWKjSCJVjnYOvjXhw==",
       "dev": true,
       "requires": {
-        "diff": "~1.0.8",
+        "diff": "^4.0.1",
         "eyes": "~0.1.6",
         "glob": "^7.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tar": "4.x"
   },
   "devDependencies": {
-    "vows": "*"
+    "vows": "^0.8.3"
   },
   "scripts": {
     "build": "node ./build/build.js",


### PR DESCRIPTION
Github has deactivate the dummy token I used to increase API limits.

That being said, it should be up to the user to increase their own limits. This removes the default OAuth authentication and reverts back to public access which should be enough for most developers.
