### PR TITLE
fix #239

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -139,7 +139,7 @@ NPMIST.downloadUrl = function(version){
 NPMIST.resolveVersionLocally = function(spec, done) {
   if (!spec) return done()
   this.listInstalled((er, installed) => {
-    if (spec === 'latest') return done(null, installed[0])
+    if (spec === 'latest') return done(null, installed[installed.length - 1])
 
     if (spec === 'match') {
       this.nodist.getCurrentVersion((er, nodeVersion) => {
@@ -364,4 +364,3 @@ NPMIST.getEnv = function getEnv(cb) {
   if(!this.envVersion) return cb();
   cb(null, this.envVersion);
 };
-

--- a/src/lib/nodist/nodist.go
+++ b/src/lib/nodist/nodist.go
@@ -131,7 +131,7 @@ func resolveVersion(spec string, installed []*semver.Version) (version string, e
   }
 
   if spec == "latest" {
-    version = installed[len(installed)-1].String()
+    version = installed[0].String()
   }else{
     for _, v := range installed {
       debug("checking %s against %s", v.String(), spec)


### PR DESCRIPTION
fix #239 
```
note: In order to create this fix, 
      I also looked at lib/nodist.js for reference, which is supposed to handle "latest" as well, 
      and found out that they use lib/version.js to handle versions. 
      Unlike lib/nodist/js, lib/npm.js has to deal with "match", 
      so it seems to have its own version handling defined.
      Following the philosophy that if you don't need to make a big change, you shouldn't, 
      I've limited myself to a small fix to npm.js. 
      But I'm curious, so I'll make a special note here.
```