### PR TITLE
Fixed: #250 cannot install new npm versions

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -57,7 +57,15 @@ NPMIST.listAvailable = function(){
       per_page: '100'
     })
   ])
-  .then(([npm, cli]) => npm.concat(cli));
+  .then(([npm, cli]) => {
+    // The npm project has two kinds of releases: releases of npm,
+    // and releases of other utility libraries.
+    // Ignore the releases of libraries. They are named "package: version",
+    // while core npm releases are named just "version".
+    cli = cli.filter( release => release.name.indexOf(':') < 0 );
+
+    return npm.concat(cli);
+  });
 };
 
 /**


### PR DESCRIPTION
The NPM project has started releasing utility libraries in its releases feed. Instead of being named "v<version>", they are named "<library>: v<version>". This unexpected format causes an error like: "Invalid Version: libnpmversion-v3.0.1." whenever you call "nodist npm add".

Solution:
Filter away the other packages when fetching the releases.