### PR TITLE
fix(npm8+): refactor symlinking to support npm 9+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - '**'
     tags-ignore:
       - '**'
+  pull_request:
 
 jobs:
   run-tests:

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -45,25 +45,30 @@ var NPMIST = npmist.prototype
  */
 async function resolveLinkedWorkspaces(dirPath) {
   let fixedLinks = 0;
-  const files = await fs.readdirAsync(dirPath, { withFileTypes: true });
-  const dirPromises = [];
-  for (const file of files) {
-    const filePath = path.join(dirPath, file.name);
-    if (file.isSymbolicLink()) {
-      const linkTarget = await fs.readlinkAsync(filePath);
-      debug('Fix symlink for ', filePath, 'with target', linkTarget);
-      await fs.unlinkAsync(filePath);
+  const packageLockJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package-lock.json')).toString());
+  await Promise.all(Object.entries(packageLockJson.packages)
+    .filter(([pkgPath, pkg]) => pkg.link === true)
+    .map(async ([pkgPath, pkg]) => {
+      const linkTarget = path.join(
+        ...pkgPath.split('/').slice(0, -1).map(() => '..'),
+        pkg.resolved
+      );
+      const linkPath = path.join(dirPath, pkgPath);
+
+      debug('Create symlink for ', linkPath, 'with target', linkTarget);
+      if (await fs.accessAsync(linkPath, fs.constants.F_OK).then(() => true).catch(() => false)) {
+        await fs.unlinkAsync(linkPath);
+      }
+
       try {
-        await fs.symlinkAsync(linkTarget, filePath, 'junction');
+        await fs.symlinkAsync(linkTarget, linkPath, 'junction');
       } catch (e) {
-        await fs.renameAsync(path.join(dirPath, linkTarget), filePath);
+        await fs.renameAsync(path.join(dirPath, linkTarget), linkPath);
       }
       fixedLinks++;
-    } else if (file.isDirectory()) {
-      dirPromises.push(resolveLinkedWorkspaces(filePath));
-    }
-  }
-  return (await Promise.all(dirPromises)).reduce((sum, num) => sum + num, fixedLinks);
+    }));
+
+  return fixedLinks;
 }
 
 /**
@@ -326,7 +331,7 @@ NPMIST.install = function(v,done){
   .then(() => {
     if (semver.gte(version, '8.0.0')) {
       debug('Fix symlinks for npm version >= 8');
-      return resolveLinkedWorkspaces(path.join(archivePath, 'node_modules'))
+      return resolveLinkedWorkspaces(path.join(archivePath))
         .then(fixedLinks => {
           debug(`Fixed ${fixedLinks} symlinks for npm node_modules`);
         });


### PR DESCRIPTION
The tarballs of npm 9 and newer don't contain the symlink files anymore. I therefore refactored the symlinking logic to use information from the package-lock.json instead which works for npm 8 and newer.