### PR TITLE
fix(npm): fetching npm versions not working

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,6 @@ jobs:
       - name: Copy Node.exe to repository directory
         run: Copy-Item (Get-Command node.exe | Select-Object -ExpandProperty Definition) .
       - run: npm test
+        env:
+          NODIST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ MIT License
 
 ## Changelog
 
+v0.10.3
+* Fix installing of npm versions
+
 v0.10.2
 * Fix building shims (for newer go versions) by using go modules
 * Fix npm shim to use correct node version

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -36,6 +36,8 @@ module.exports = npmist
 
 var NPMIST = npmist.prototype
 
+const versionRegex = /^v\d+\.\d+\.\d+$/;
+
 /**
  * List available NPM versions
  * @return {string}
@@ -60,10 +62,9 @@ NPMIST.listAvailable = function(){
   .then(([npm, cli]) => {
     // The npm project has two kinds of releases: releases of npm,
     // and releases of other utility libraries.
-    // Ignore the releases of libraries. They are named "package: version",
+    // Ignore the releases of libraries. They are named "library-version",
     // while core npm releases are named just "version".
-    cli = cli.filter( release => release.name.indexOf(':') < 0 );
-
+    cli = cli.filter(release => versionRegex.test(release));
     return npm.concat(cli);
   });
 };
@@ -111,7 +112,7 @@ function getNpmReleases(page) {
     per_page: 50,
     page,
   }).then((response) => response.data.map(release => release.tag_name)
-    .filter((version) => /^v\d+\.\d+\.\d+$/.test(version))
+    .filter((version) => versionRegex.test(version))
     .sort(semver.compare)
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodist",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nodist",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodist",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Natural node version manager for windows",
   "keywords": [
     "node",

--- a/test/npm-test.js
+++ b/test/npm-test.js
@@ -7,6 +7,7 @@ const Npmist = require('../lib/npm');
 const { createNodistInstance, promiseWithCallback } = require('./helper');
 
 const npmBaseVersion = '6.10.1';
+const versionRegex = /^v\d+\.\d+\.\d+/;
 
 vows.describe('npm')
   .addBatch({
@@ -17,7 +18,16 @@ vows.describe('npm')
         'should return valid version number': (error, result) => {
           assert.ifError(error);
           debug('latestVersion: ' + result);
-          assert.match(result, /^v\d+\.\d+\.\d+$/);
+          assert.match(result, versionRegex);
+        }
+      },
+      'calling `listAvailable()`': {
+        topic(npmist) { promiseWithCallback(npmist.listAvailable(), this.callback); },
+        'should return an array of available versions': (error, result) => {
+          assert.ifError(error);
+          debug('listVersions: ' + result);
+          assert.ok(Array.isArray(result));
+          result.forEach((version) => assert.match(version, versionRegex));
         }
       }
     }


### PR DESCRIPTION
Sadly a [change that I was unaware of](https://github.com/nodists/nodist/pull/260) broke the installation of npm versions, fixed that and prepared a new version.